### PR TITLE
Remove the error redirections

### DIFF
--- a/bin/pyenv-pip-update
+++ b/bin/pyenv-pip-update
@@ -27,7 +27,7 @@ then # If no argument is given, update libraries using pip
             conda update --all
         elif pip >/dev/null 2>&1
         then
-            stale_packages="$(pip list --format=freeze --outdated 2> >(grep -iv '^deprecation:') | awk -F '==' '{printf "%s ", $1}')"
+            stale_packages="$(pip list --format=freeze --outdated | awk -F '==' '{printf "%s ", $1}')"
             if [ ! -z "${stale_packages}" ]
             then
                 if [[ "$v" =~ ^system ]]; then


### PR DESCRIPTION
Not sure why we had those there in the first place because, now every other error is being redirected to standard output and interfering with the output of pip.

Example output:
```
appdirs certifi distlib gitdb GitPython idna importlib-metadata pbr pip PyGObject requests setuptools six smmap stevedore urllib3 virtualenv virtualenv-clone zipp WARNING: You are using pip version 20.0.2; however, version 20.1.1 is available. You should consider upgrading via the '/home/chigozirim/.pyenv/versions/3.7.3/bin/python3.7 -m pip install --upgrade pip' command.
```

With this PR, the errors go to standard error while the correct output is added to the `stale_packages` variable