### PR TITLE
pip no longer supports list --outdated with freeze format

### DIFF
--- a/bin/pyenv-pip-update
+++ b/bin/pyenv-pip-update
@@ -27,7 +27,7 @@ then # If no argument is given, update libraries using pip
             conda update --all
         elif pip >/dev/null 2>&1
         then
-            stale_packages="$(pip list --format=freeze --outdated | awk -F '==' '{printf "%s ", $1}')"
+            stale_packages="$(pip --disable-pip-version-check list --outdated | awk 'NR>3 {print $1}')"
             if [ ! -z "${stale_packages}" ]
             then
                 if [[ "$v" =~ ^system ]]; then

--- a/bin/pyenv-pip-update
+++ b/bin/pyenv-pip-update
@@ -27,7 +27,7 @@ then # If no argument is given, update libraries using pip
             conda update --all
         elif pip >/dev/null 2>&1
         then
-            stale_packages="$(pip --disable-pip-version-check list --outdated | awk 'NR>3 {print $1}')"
+            stale_packages="$(pip --disable-pip-version-check list --outdated | awk 'NR>2 {print $1}')"
             if [ ! -z "${stale_packages}" ]
             then
                 if [[ "$v" =~ ^system ]]; then


### PR DESCRIPTION
After pip version 22.3, the --outdated and --format=freeze were made [mutually exclusive](https://github.com/pypa/pip/issues/9789).

This patch merely uses the standard outdated format (pip list --outdated), which contains two header lines that awk needs to skip. Otherwise, awk simply extracts the package name from the first column.