### PR TITLE
Remove quotes around packages to update

### DIFF
--- a/bin/pyenv-pip-update
+++ b/bin/pyenv-pip-update
@@ -44,7 +44,7 @@ do
             echo -e "\e[1;31mSystem pip detected. Update manually and cautiously\e[m"
             echo -e "\e[1;34mUse: 'pip install --upgrade ${stale_packages[*]}'\e[m"
         else
-            pip install --upgrade "${stale_packages[@]}"
+            pip install --upgrade ${stale_packages[@]}
         fi
     else
         echo -e "\e[1;31mCommand not found: conda\e[m"

--- a/bin/pyenv-pip-update
+++ b/bin/pyenv-pip-update
@@ -44,6 +44,7 @@ do
             echo -e "\e[1;31mSystem pip detected. Update manually and cautiously\e[m"
             echo -e "\e[1;34mUse: 'pip install --upgrade ${stale_packages[*]}'\e[m"
         else
+            # shellcheck disable=SC2068
             pip install --upgrade ${stale_packages[@]}
         fi
     else


### PR DESCRIPTION
This must have been a regression. Quoting the array of packages causes them to be sent to pip as a single command, and it fails to update